### PR TITLE
Add support for lower- or mixed-cased values on environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ var hasUnicode = module.exports = function () {
   // appropriate.
   if (os.type() == "Windows_NT") { return false }
 
-  var isUTF8 = /[.]UTF-8/
+  var isUTF8 = /UTF-?8/i
   if (isUTF8.test(process.env.LC_ALL)
-   || process.env.LC_CTYPE == 'UTF-8'
+   || isUTF8.test(process.env.LC_CTYPE)
    || isUTF8.test(process.env.LANG)) {
     return true
   }

--- a/test/index.js
+++ b/test/index.js
@@ -10,17 +10,37 @@ test("Windows", function (t) {
   t.is(hasUnicode(), false, "Windows is assumed NOT to be unicode aware")
 })
 test("Unix Env", function (t) {
-  t.plan(3)
+  t.plan(7)
   var hasUnicode = requireInject("../index.js", {
     os: { type: function () { return "Linux" } },
     child_process: { exec: function (cmd,cb) { cb(new Error("not available")) } }
   })
   process.env.LANG = "en_US.UTF-8"
   process.env.LC_ALL = null
+  process.env.LC_CTYPE = null
   t.is(hasUnicode(), true, "Linux with a UTF8 language")
+  process.env.LANG = "en_US.utf8"
+  process.env.LC_ALL = null
+  process.env.LC_CTYPE = null
+  t.is(hasUnicode(), true, "Linux with a UTF8 language (lower case, unhyphenated)")
   process.env.LANG = null
   process.env.LC_ALL = "en_US.UTF-8"
+  process.env.LC_CTYPE = null
   t.is(hasUnicode(), true, "Linux with UTF8 locale")
+  process.env.LANG = null
+  process.env.LC_ALL = "en_US.utf8"
+  process.env.LC_CTYPE = null
+  t.is(hasUnicode(), true, "Linux with UTF8 locale (lower case, unhyphenated)")
+  process.env.LANG = null
   process.env.LC_ALL = null
+  process.env.LC_CTYPE = 'UTF-8'
+  t.is(hasUnicode(), true, "Linux with UTF8 CTYPE")
+  process.env.LANG = null
+  process.env.LC_ALL = null
+  process.env.LC_CTYPE = 'utf8'
+  t.is(hasUnicode(), true, "Linux with UTF8 CTYPE (lower case, unhyphenated)")
+  process.env.LC_ALL = null
+  process.env.LC_LANG = null
+  process.env.LC_CTYPE = null
   t.is(hasUnicode(), false, "Linux without UTF8 language or locale")
 })


### PR DESCRIPTION
In my current Linux installation (Manjaro, installed two years ago) the variable `LANG` reports a value of `en_US.utf8`, with that exact case.  This made this package detect my system as _not_ supporting UTF-8 and therefore some applications (particularly `npm`) don't use their nicer display modes. This pull request addresses this by making all checks case-agnostic.

It also includes tests for lowercase strings, and I've added a missing test for the `LC_CTYPE` variable, which was missing.

This addresses #2
