### PR TITLE
Several improvements for non-Windows systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,7 @@ var hasUnicode = module.exports = function () {
   // appropriate.
   if (os.type() == "Windows_NT") { return false }
 
-  var isUTF8 = /[.]UTF-8/
-  if (isUTF8.test(process.env.LC_ALL)
-   || process.env.LC_CTYPE == 'UTF-8'
-   || isUTF8.test(process.env.LANG)) {
-    return true
-  }
-
-  return false
+  var isUTF8 = /UTF-?8/i
+  var ctype = process.env.LC_ALL || process.env.LC_CTYPE || process.env.LANG
+  return isUTF8.test(ctype)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,17 +10,25 @@ test("Windows", function (t) {
   t.is(hasUnicode(), false, "Windows is assumed NOT to be unicode aware")
 })
 test("Unix Env", function (t) {
-  t.plan(3)
   var hasUnicode = requireInject("../index.js", {
     os: { type: function () { return "Linux" } },
     child_process: { exec: function (cmd,cb) { cb(new Error("not available")) } }
   })
-  process.env.LANG = "en_US.UTF-8"
-  process.env.LC_ALL = null
-  t.is(hasUnicode(), true, "Linux with a UTF8 language")
-  process.env.LANG = null
-  process.env.LC_ALL = "en_US.UTF-8"
-  t.is(hasUnicode(), true, "Linux with UTF8 locale")
-  process.env.LC_ALL = null
-  t.is(hasUnicode(), false, "Linux without UTF8 language or locale")
+  function test3(LC_ALL, LC_CTYPE, LANG, expected, comment) {
+    var env = process.env
+    if (LC_ALL)   env.LC_ALL   = LC_ALL;   else delete env.LC_ALL
+    if (LC_CTYPE) env.LC_CTYPE = LC_CTYPE; else delete env.LC_CTYPE
+    if (LANG)     env.LANG     = LANG;     else delete env.LANG
+    t.is(hasUnicode(), expected, comment)
+  }
+  test3(null, null, "en_US.UTF-8", true, "Linux with a UTF-8 language")
+  test3("en_US.UTF-8", null, null, true, "Linux with UTF-8 locale")
+  test3(null, null, null, false, "Linux with no locale setting at all")
+  test3(null, "en_US.UTF-8", null, true, "Linux with UTF-8 in character type")
+  test3(null, "UTF-8", null, true, "Linux with UTF-8 as character type")
+  test3("C", "en_US.UTF-8", "en_US.UTF-8", false, "LC_ALL overrides")
+  test3(null, "en_US", "en_US.UTF-8", false, "LC_CTYPE overrides LANG")
+  test3(null, null, null, false, "Linux with no locale setting at all")
+  test3(null, null, "de_DE.utf8", true, "Linux with utf8 language")
+  t.end()
 })


### PR DESCRIPTION
- Allow lowercase unhyphenated `utf8`
- Allow `LC_CTYPE` to contain language as well as encoding
- Relax formatting requirements, so `foo_BAR@utf-8.quotes` or similar gets accepted as well
- Handle overrides correctly, using the highest priority non-empty setting
- Simplify test suite by reducing each test to one line
- Fix tests since assigning `null` or `undefined` to `process.env` will stringify that (at least on my Node 5.3.0), instead of unsetting the variable

This fixes #2. I consider this solution superior to #3, so personally I'd say it supersedes that.
