### PR TITLE
Added Support for Linux On Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - "7"
   - "6"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/has-unicode/builds/209185189
Please have a look.

Regards,
ujjwal